### PR TITLE
Remove 8x logs to 4x chests from kubejs recipe

### DIFF
--- a/kubejs/server_scripts/mods/minecraft/recipes.js
+++ b/kubejs/server_scripts/mods/minecraft/recipes.js
@@ -80,11 +80,4 @@ ServerEvents.recipes((event) => {
   event.shapeless("minecraft:black_dye", ["minecraft:charcoal"]);
   // Bone to bonemeal
   event.smelting("3x minecraft:bone_meal", "minecraft:bone").xp(0.05);
-  // 8x logs -> 4x chests through shaped crafting
-  // event.shaped("4x minecraft:chest", ["XXX", "X X", "XXX"], {
-  //   X: "#minecraft:logs",
-  // });
-  event.shaped("minecraft:chest", ["YYY", "Y Y", "YYY"], {
-    Y: "#minecraft:logs"
-  });
 });


### PR DESCRIPTION
Since Utilitarian already provide this recipe, we don't need. Also, it was broken since it makes only one.

![image](https://github.com/AllTheMods/All-the-mods-9-Sky/assets/26970092/928000ad-75df-41b8-9056-2e23dc430190)
![image](https://github.com/AllTheMods/All-the-mods-9-Sky/assets/26970092/5c91b808-3bce-488a-8793-599c525c454a)
