### PR TITLE
Add in tool tip for allthemodium upgrades in smithing table

### DIFF
--- a/kubejs/assets/kubejs/lang/en_us.json
+++ b/kubejs/assets/kubejs/lang/en_us.json
@@ -3373,6 +3373,14 @@
     "atm9.quest.occultism.familiars.2": "&dFamiliars&r",
 	
 	
+
+    "item.allthemodium.smithing_template.allthemodium_upgrade.base_slot_description": "Add Netherite Armor, Weapon, or Tool",
+    "item.allthemodium.smithing_template.allthemodium_upgrade.additions_slot_description": "Add Allthemodium Ingot",
+    "item.allthemodium.smithing_template.vibranium_upgrade.base_slot_description": "Add Allthemodium Armor, Weapon, or Tool",
+    "item.allthemodium.smithing_template.vibranium_upgrade.additions_slot_description": "Add Vibranium Ingot",
+    "item.allthemodium.smithing_template.unobtainium_upgrade.base_slot_description": "Add Vibranium Armor, Weapon, or Tool",
+    "item.allthemodium.smithing_template.unobtainium_upgrade.additions_slot_description": "Add Unobtainium Ingot",
+	
     "item.kubejs.micro_universe_catalyst.tooltip": "Forged in the fire of a thousand suns.",
 	"kubejs.apiary_ii.tooltip.bee_requirements": "Requires Very High, Any, Metaturnal bees to run",
 	"kubejs.apiary_i.tooltip.bee_eater": "Occasionally eats the bees"


### PR DESCRIPTION
This PR fixes [Pull 79](https://github.com/AllTheMods/AllTheModium/pull/79#issue-2358469901) in the AllTheModium mod by adding the missing strings in the kubejs lang file.

This PR would be made obsolete by the AllTheModium mod getting updated. 

Before
![image](https://github.com/AllTheMods/All-the-mods-9-Sky/assets/61364477/aab90997-ccc3-45bb-afe5-914f666b83ac)

After
![image](https://github.com/AllTheMods/All-the-mods-9-Sky/assets/61364477/e5e6e0c3-c5c3-43cf-bbd9-915d46be9492)
