### PR TITLE
Chipped Moss Blocks Removed from SquatGrow

### DIFF
--- a/config/squatgrow-common.yaml
+++ b/config/squatgrow-common.yaml
@@ -8,7 +8,7 @@ enableDirtToGrass: true
 enableMysticalCrops: true
 hoeTakesDamage: false
 ignoreList: ['minecraft:grass_block', 'minecraft:grass', 'minecraft:tall_grass', 'minecraft:netherrack',
-  'minecraft:warped_nylium', 'minecraft:crimson_nylium', 'minecraft:sunflower', 'minecraft:rose_bush', 'minecraft:pink_petals', 'minecraft:moss_block']
+  'minecraft:warped_nylium', 'minecraft:crimson_nylium', 'minecraft:sunflower', 'minecraft:rose_bush', 'minecraft:pink_petals', '#chipped:moss_block']
 randomTickMultiplier: 4
 range: 3
 requireHoe: false


### PR DESCRIPTION
Small change, sorry for the PR. This worked fine on my end.

Fixes: https://github.com/AllTheMods/All-the-mods-9-Sky/issues/481